### PR TITLE
Tweak to support paths with spaces

### DIFF
--- a/build2phone.sh
+++ b/build2phone.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 
- xcodebuild -project `pwd`/build/iphone/*.xcodeproj -configuration Debug  -sdk iphoneos CONFIGURATION_BUILD_DIR="`pwd`/build/iphone/build/"
+ xcodebuild -project "`pwd`"/build/iphone/*.xcodeproj -configuration Debug  -sdk iphoneos CONFIGURATION_BUILD_DIR="`pwd`/build/iphone/build/"
 
 
-~/.b2i/bin/mobiledevice install_app `pwd`/build/iphone/build/*.app
+~/.b2i/bin/mobiledevice install_app "`pwd`"/build/iphone/build/*.app
 
   
 


### PR DESCRIPTION
Wasn't working with default "Titanium Studio Workspaces" paths - added quick fix and tested successfully.
